### PR TITLE
Assign Tag on Product Purchase

### DIFF
--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -453,6 +453,33 @@ class ConvertKit_MM_Admin {
 	}
 
 	/**
+	 * Assign a tag to the subscriber when purchasing a MemberMouse Product
+	 * that is configured to tag a subscriber.
+	 * 
+	 * @since 	1.2.0
+	 * 
+	 * @param 	array 	$purchase_data 	Checkout purchase data.
+	 */
+	public function purchase_product( $purchase_data ) {
+
+		// Fetch data from purchase array.
+		$user_email = $purchase_data['email'];
+		$first_name = rawurlencode( $purchase_data['first_name'] );
+		$mapping    = 'convertkit-mapping-product-' . $purchase_data['product_id'] . '-cancel';
+		$tag_id     = $this->get_option( $mapping );
+
+		// If no tag assigned to this Product, bail.
+		if ( empty( $tag_id ) ) {
+			return;
+		}
+
+		// Assign tag to subscriber in ConvertKit.
+		$this->api->add_tag_to_user( $user_email, $first_name, $tag_id );
+		convertkit_mm_log( 'tag', 'Add product tag ' . $tag_id . ' to user ' . $user_email . ' (' . $first_name . ')' );
+
+	}
+
+	/**
 	 * Get the setting option requested.
 	 *
 	 * @since   1.0.0

--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -147,11 +147,11 @@ class ConvertKit_MM_Admin {
 		}
 
 		// Output product to tag mappings.
-		if ( empty( $levels ) ) {
+		if ( empty( $products ) ) {
 			add_settings_field(
 				'convertkit-empty-mapping',
-				apply_filters( $this->plugin_name . '_display_convertkit_mapping', esc_html__( 'Mapping', 'convertkit-mm' ) ),
-				array( $this, 'display_options_empty_mapping' ),
+				apply_filters( $this->plugin_name . '_display_convertkit_mapping_product', esc_html__( 'Mapping', 'convertkit-mm' ) ),
+				array( $this, 'display_options_empty_mapping_products' ),
 				$this->plugin_name,
 				$this->plugin_name . '-ck-mapping'
 			);
@@ -374,6 +374,29 @@ class ConvertKit_MM_Admin {
 				</select>
 			<?php
 		}
+
+	}
+
+
+	/**
+	 * Outputs a notice in the Mapping section when no MemberMouse products have been added
+	 *
+	 * @since       1.2.0
+	 */
+	public function display_options_empty_mapping_products() {
+
+		?>
+		<p>
+			<?php echo esc_html__( 'No MM Products have been added yet.', 'convertkit-mm' ); ?><br/>
+			<?php
+			printf(
+				/* translators: Link to MemberMouse Membership Levels */
+				esc_html__( 'You can add one <a href="%s">here</a>.', 'convertkit-mm' ),
+				esc_url( get_admin_url( null, '/admin.php?page=product_settings' ) )
+			);
+			?>
+		</p>
+		<?php
 
 	}
 

--- a/includes/class-convertkit-mm.php
+++ b/includes/class-convertkit-mm.php
@@ -146,10 +146,15 @@ class ConvertKit_MM {
 		$this->loader->add_filter( 'plugin_action_links_convertkit-membermouse/convertkit-membermouse.php', $plugin_admin, 'settings_link' );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_menu' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+
+		// Tag on Membership Level.
 		$this->loader->add_action( 'mm_member_add', $plugin_admin, 'add_member' );
 		$this->loader->add_action( 'mm_member_membership_change', $plugin_admin, 'add_member' );
 		$this->loader->add_action( 'mm_member_status_change', $plugin_admin, 'status_change_member' );
 		$this->loader->add_action( 'mm_member_delete', $plugin_admin, 'delete_member' );
+
+		// Tag on Product.
+		$this->loader->add_action( 'mm_product_purchase', $plugin_admin, 'purchase_product' );
 
 	}
 

--- a/tests/_support/Helper/Acceptance/MemberMouse.php
+++ b/tests/_support/Helper/Acceptance/MemberMouse.php
@@ -34,4 +34,27 @@ class MemberMouse extends \Codeception\Module
 			]
 		);
 	}
+
+	/**
+	 * Helper method to create a product.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 * @param   string           $name  Product Name.
+	 * @param   string           $key   Product Reference Key.
+	 * @return  int                     Product ID.
+	 */
+	public function memberMouseCreateProduct($I, $name, $key)
+	{
+		return $I->haveInDatabase(
+			'wp_mm_products',
+			[
+				'reference_key' => $key,
+				'status'        => 1,
+				'name'          => $name,
+				'price'         => 1,
+			]
+		);
+	}
 }

--- a/tests/acceptance/general/ProductTagCest.php
+++ b/tests/acceptance/general/ProductTagCest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Tests that subscribers are added to ConvertKit and tagged
+ * based on the product purchased.
+ *
+ * @since   1.2.0
+ */
+class ProductTagCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate Plugins.
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'membermouse-platform');
+	}
+
+	/**
+	 * Test that the member is tagged with the configured "apply tag on add"
+	 * setting when added to a Membership Level.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberTaggedWhenProductPurchased(AcceptanceTester $I)
+	{
+		// Create a product.
+		$productReferenceKey = 'pTRLc9';
+		$productID           = $I->memberMouseCreateProduct($I, 'Product', $productReferenceKey);
+
+		// Setup Plugin to tag users purchasing the product to the
+		// ConvertKit Tag ID.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-product-1' => $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Enable test mode for payments.
+		$I->amOnAdminPage('admin.php?page=payment_settings');
+		$I->checkOption('test_payment_service_enabled');
+		$I->click('Save Payment Methods');
+		$I->wait(5);
+		$I->acceptPopup();
+
+		// Logout.
+		// We don't use logOut() as MemberMouse hijacks the logout process with a redirect,
+		// resulting in the logOut() assertion `loggedout=true` failing.
+		$I->amOnPage('wp-login.php?action=logout');
+		$I->click("//a[contains(@href,'action=logout')]");
+
+		// Navigate to purchase screen for the product.
+		$I->amOnPage('checkout/?rid=' . $productReferenceKey);
+
+		// Complete checkout.
+		$I->fillField('mm_field_first_name', 'First');
+		$I->fillField('mm_field_last_name', 'Last');
+		$I->fillField('mm_field_email', $emailAddress);
+		$I->fillField('mm_field_password', '12345678');
+		$I->fillField('mm_field_phone', '12345678');
+		$I->fillField('mm_field_cc_number', '4242424242424242');
+		$I->fillField('mm_field_cc_cvv', '123');
+		$I->selectOption('mm_field_cc_exp_year', '2038');
+		$I->fillField('mm_field_billing_address', '123 Main Street');
+		$I->fillField('mm_field_billing_city', 'Nashville');
+		$I->selectOption('#mm_field_billing_state_dd', 'Tennessee');
+		$I->fillField('mm_field_billing_zip', '37208');
+
+		// Submit.
+		$I->click('Submit Order');
+
+		// Wait for confirmation.
+		$I->waitForText('Thank you for your order');
+
+		// Check subscriber exists.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'membermouse-platform');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}


### PR DESCRIPTION
## Summary

Adds requested functionality to tag a subscriber based on the MemberMouse product purchased.

<img width="986" alt="Screenshot 2024-07-02 at 15 54 50" src="https://github.com/ConvertKit/convertkit-membermouse/assets/1462305/9de1d39c-bdd6-4079-bfad-44ba6a0e90a4">

## Testing

- `ProductTagCest`: Tests that members are subscribed and tagged in ConvertKit when configured to do so in the Plugin's settings

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)