### PR TITLE
Add 'None' option for Tagging

### DIFF
--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -343,12 +343,8 @@ class ConvertKit_MM_Admin {
 		} else {
 			?>
 				<select id="<?php echo esc_attr( $this->plugin_name ); ?>-options[<?php echo esc_attr( $option_name ); ?>]" name="<?php echo esc_attr( $this->plugin_name ); ?>-options[<?php echo esc_attr( $option_name ); ?>]">
+					<option value=""<?php selected( $tag, '' ); ?>><?php echo esc_attr__( '(None)', 'convertkit-mm' ); ?></option>
 					<?php
-					if ( empty( $tag ) ) {
-						?>
-						<option value=""><?php echo esc_attr__( 'Select a tag', 'convertkit-mm' ); ?></option>
-						<?php
-					}
 					foreach ( $args['tags'] as $value => $text ) {
 						?>
 						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $tag, $value ); ?>><?php echo esc_attr( $text ); ?></option>
@@ -359,12 +355,8 @@ class ConvertKit_MM_Admin {
 			</td>
 			<td>
 				<select id="<?php echo esc_attr( $this->plugin_name ); ?>-options[<?php echo esc_attr( $option_name ); ?>-cancel]" name="<?php echo esc_attr( $this->plugin_name ); ?>-options[<?php echo esc_attr( $option_name ); ?>-cancel]">
+					<option value=""<?php selected( $tag_cancel, '' ); ?>><?php echo esc_attr__( '(None)', 'convertkit-mm' ); ?></option>
 					<?php
-					if ( empty( $tag_cancel ) ) {
-						?>
-						<option value=""><?php echo esc_attr__( 'Select a tag', 'convertkit-mm' ); ?></option>
-						<?php
-					}
 					foreach ( $args['tags'] as $value => $text ) {
 						?>
 						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $tag_cancel, $value ); ?>><?php echo esc_attr( $text ); ?></option>

--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -416,12 +416,8 @@ class ConvertKit_MM_Admin {
 		} else {
 			?>
 				<select id="<?php echo esc_attr( $this->plugin_name ); ?>-options[<?php echo esc_attr( $option_name ); ?>]" name="<?php echo esc_attr( $this->plugin_name ); ?>-options[<?php echo esc_attr( $option_name ); ?>]">
+					<option value=""<?php selected( $tag, '' ); ?>><?php echo esc_attr__( '(None)', 'convertkit-mm' ); ?></option>
 					<?php
-					if ( empty( $tag ) ) {
-						?>
-						<option value=""><?php echo esc_attr__( 'Select a tag', 'convertkit-mm' ); ?></option>
-						<?php
-					}
 					foreach ( $args['tags'] as $value => $text ) {
 						?>
 						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $tag, $value ); ?>><?php echo esc_attr( $text ); ?></option>

--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -147,11 +147,11 @@ class ConvertKit_MM_Admin {
 		}
 
 		// Output product to tag mappings.
-		if ( empty( $levels ) ) {
+		if ( empty( $products ) ) {
 			add_settings_field(
 				'convertkit-empty-mapping',
-				apply_filters( $this->plugin_name . '_display_convertkit_mapping', esc_html__( 'Mapping', 'convertkit-mm' ) ),
-				array( $this, 'display_options_empty_mapping' ),
+				apply_filters( $this->plugin_name . '_display_convertkit_mapping_product', esc_html__( 'Mapping', 'convertkit-mm' ) ),
+				array( $this, 'display_options_empty_mapping_products' ),
 				$this->plugin_name,
 				$this->plugin_name . '-ck-mapping'
 			);
@@ -374,6 +374,29 @@ class ConvertKit_MM_Admin {
 				</select>
 			<?php
 		}
+
+	}
+
+
+	/**
+	 * Outputs a notice in the Mapping section when no MemberMouse products have been added
+	 *
+	 * @since       1.2.0
+	 */
+	public function display_options_empty_mapping_products() {
+
+		?>
+		<p>
+			<?php echo esc_html__( 'No MM Products have been added yet.', 'convertkit-mm' ); ?><br/>
+			<?php
+			printf(
+				/* translators: Link to MemberMouse Membership Levels */
+				esc_html__( 'You can add one <a href="%s">here</a>.', 'convertkit-mm' ),
+				esc_url( get_admin_url( null, '/admin.php?page=product_settings' ) )
+			);
+			?>
+		</p>
+		<?php
 
 	}
 

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -78,6 +78,28 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Check the given subscriber ID has been assigned to the given number
+	 * of tags.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 * @param   int              $numberOfTags  Number of tags.
+	 */
+	public function apiCheckSubscriberTagCount($I, $subscriberID, $numberOfTags)
+	{
+		// Run request.
+		$results = $this->apiRequest(
+			'subscribers/' . $subscriberID . '/tags',
+			'GET'
+		);
+
+		// Confirm the correct number of tags have been assigned to the subscriber.
+		$I->assertEquals($numberOfTags, count($results['tags']));
+	}
+
+	/**
 	 * Check the given email address does not exists as a subscriber.
 	 *
 	 * @since   1.2.0

--- a/tests/acceptance/general/MemberTagCest.php
+++ b/tests/acceptance/general/MemberTagCest.php
@@ -278,6 +278,270 @@ class MemberTagCest
 	}
 
 	/**
+	 * Test that the member is not subscribed or tagged when the configured "apply tag on add"
+	 * setting is set to 'None', and the member is added to a Membership Level.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberNotTaggedWhenMembershipLevelAdded(AcceptanceTester $I)
+	{
+		// Setup Plugin to not tag users added to the Free Membership level to the
+		// ConvertKit Tag ID.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-1' => '',
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Navigate to MemberMouse > Manage Members.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+
+		// Create Member.
+		$I->click('Create Member');
+		$I->waitForElementVisible('#mm-new-member-form-container');
+		$I->fillField('#mm-new-first-name', 'First');
+		$I->fillField('#mm-new-last-name', 'Last');
+		$I->fillField('#mm-new-email', $emailAddress);
+		$I->fillField('#mm-new-password', '12345678');
+		$I->click('Create Member', '.mm-dialog-button-container');
+		$I->waitForElementNotVisible('#mm-new-member-form-container');
+
+		// Accept popup once user created.
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed adding the member.
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+
+		// Check subscriber does not exist.
+		$subscriberID = $I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
+	}
+
+	/**
+	 * Test that the member is not tagged when the configured "apply tag on add"
+	 * setting is set to 'None' and the Membership Level is changed.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberNotTaggedWhenMembershipLevelChanged(AcceptanceTester $I)
+	{
+		// Create an additional membership level.
+		$levelID = $I->memberMouseCreateMembershipLevel($I, 'Premium');
+
+		// Setup Plugin to tag users added to the Free Membership level to the
+		// ConvertKit Tag ID, but not tag when migrated to the Premium Membership
+		// level.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-1'           => $_ENV['CONVERTKIT_API_TAG_ID'],
+				'convertkit-mapping-' . $levelID => '',
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Navigate to MemberMouse > Manage Members.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+
+		// Create Member.
+		$I->click('Create Member');
+		$I->waitForElementVisible('#mm-new-member-form-container');
+		$I->fillField('#mm-new-first-name', 'First');
+		$I->fillField('#mm-new-last-name', 'Last');
+		$I->fillField('#mm-new-email', $emailAddress);
+		$I->fillField('#mm-new-password', '12345678');
+		$I->click('Create Member', '.mm-dialog-button-container');
+		$I->waitForElementNotVisible('#mm-new-member-form-container');
+
+		// Accept popup once user created.
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed adding the member.
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+
+		// Check subscriber exists.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+
+		// Change the user's membership level.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+		$I->click($emailAddress);
+		$I->click('Access Rights');
+		$I->selectOption('#mm-new-membership-selection', 'Premium');
+		$I->click('Change Membership');
+
+		// Accept popups
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed changing the membership level.
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+
+		// Check subscriber exists.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber is still assigned to the first tag and has no additional tags.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberTagCount($I, $subscriberID, 1);
+	}
+
+	/**
+	 * Test that the member is not tagged when the configured "apply tag on cancel"
+	 * setting is set to 'None' and the Membership Level is removed.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberNotTaggedWhenMembershipLevelCancelled(AcceptanceTester $I)
+	{
+		// Setup Plugin to tag users added to the Free Membership level to the
+		// ConvertKit Tag ID, but not assign a different tag when their membership
+		// is cancelled.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-1'        => $_ENV['CONVERTKIT_API_TAG_ID'],
+				'convertkit-mapping-1-cancel' => '',
+
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Navigate to MemberMouse > Manage Members.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+
+		// Create Member.
+		$I->click('Create Member');
+		$I->waitForElementVisible('#mm-new-member-form-container');
+		$I->fillField('#mm-new-first-name', 'First');
+		$I->fillField('#mm-new-last-name', 'Last');
+		$I->fillField('#mm-new-email', $emailAddress);
+		$I->fillField('#mm-new-password', '12345678');
+		$I->click('Create Member', '.mm-dialog-button-container');
+		$I->waitForElementNotVisible('#mm-new-member-form-container');
+
+		// Accept popup once user created.
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed adding the member.
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+
+		// Check subscriber exists.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+
+		// Cancel the user's membership level.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+		$I->click($emailAddress);
+		$I->click('Access Rights');
+		$I->click('Cancel Membership');
+
+		// Accept popups
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed changing the membership level.
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+
+		// Check that the subscriber is still assigned to the first tag and has no additional tags.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberTagCount($I, $subscriberID, 1);
+	}
+
+	/**
+	 * Test that the member is not tagged when the configured "apply tag on cancel"
+	 * setting is set to 'None' and the member is deleted.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberNotTaggedWhenDeleted(AcceptanceTester $I)
+	{
+		// Setup Plugin to tag users added to the Free Membership level to the
+		// ConvertKit Tag ID, but not assign them a different tag when their membership
+		// is cancelled through account deletion.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-1'        => $_ENV['CONVERTKIT_API_TAG_ID'],
+				'convertkit-mapping-1-cancel' => '',
+
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Navigate to MemberMouse > Manage Members.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+
+		// Create Member.
+		$I->click('Create Member');
+		$I->waitForElementVisible('#mm-new-member-form-container');
+		$I->fillField('#mm-new-first-name', 'First');
+		$I->fillField('#mm-new-last-name', 'Last');
+		$I->fillField('#mm-new-email', $emailAddress);
+		$I->fillField('#mm-new-password', '12345678');
+		$I->click('Create Member', '.mm-dialog-button-container');
+		$I->waitForElementNotVisible('#mm-new-member-form-container');
+
+		// Accept popup once user created.
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed adding the member.
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+
+		// Check subscriber exists.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+
+		// Cancel the user's membership level.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+		$I->click($emailAddress);
+		$I->click('Delete Member');
+
+		// Accept popups
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed changing the membership level.
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+		$I->acceptPopup();
+		$I->wait(3);
+
+		// Check that the subscriber is still assigned to the first tag and has no additional tags.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberTagCount($I, $subscriberID, 1);
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/general/ProductTagCest.php
+++ b/tests/acceptance/general/ProductTagCest.php
@@ -23,7 +23,7 @@ class ProductTagCest
 
 	/**
 	 * Test that the member is tagged with the configured "apply tag on add"
-	 * setting when added to a Membership Level.
+	 * setting when purchasing the given product.
 	 *
 	 * @since   1.2.0
 	 *
@@ -88,6 +88,72 @@ class ProductTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+	}
+
+	/**
+	 * Test that the member is not tagged when the configured "apply tag on add"
+	 * setting is "none" for the given purchased product.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberNotTaggedWhenProductPurchased(AcceptanceTester $I)
+	{
+		// Create a product.
+		$productReferenceKey = 'pTRLc9';
+		$productID           = $I->memberMouseCreateProduct($I, 'Product', $productReferenceKey);
+
+		// Setup Plugin to not tag users purchasing the product to the
+		// ConvertKit Tag ID.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-product-1' => '',
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Enable test mode for payments.
+		$I->amOnAdminPage('admin.php?page=payment_settings');
+		$I->checkOption('test_payment_service_enabled');
+		$I->click('Save Payment Methods');
+		$I->wait(5);
+		$I->acceptPopup();
+
+		// Logout.
+		// We don't use logOut() as MemberMouse hijacks the logout process with a redirect,
+		// resulting in the logOut() assertion `loggedout=true` failing.
+		$I->amOnPage('wp-login.php?action=logout');
+		$I->click("//a[contains(@href,'action=logout')]");
+
+		// Navigate to purchase screen for the product.
+		$I->amOnPage('checkout/?rid=' . $productReferenceKey);
+
+		// Complete checkout.
+		$I->fillField('mm_field_first_name', 'First');
+		$I->fillField('mm_field_last_name', 'Last');
+		$I->fillField('mm_field_email', $emailAddress);
+		$I->fillField('mm_field_password', '12345678');
+		$I->fillField('mm_field_phone', '12345678');
+		$I->fillField('mm_field_cc_number', '4242424242424242');
+		$I->fillField('mm_field_cc_cvv', '123');
+		$I->selectOption('mm_field_cc_exp_year', '2038');
+		$I->fillField('mm_field_billing_address', '123 Main Street');
+		$I->fillField('mm_field_billing_city', 'Nashville');
+		$I->selectOption('#mm_field_billing_state_dd', 'Tennessee');
+		$I->fillField('mm_field_billing_zip', '37208');
+
+		// Submit.
+		$I->click('Submit Order');
+
+		// Wait for confirmation.
+		$I->waitForText('Thank you for your order');
+
+		// Check subscriber does not exist.
+		$subscriberID = $I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 	}
 
 	/**

--- a/tests/acceptance/general/SettingsCest.php
+++ b/tests/acceptance/general/SettingsCest.php
@@ -112,6 +112,7 @@ class SettingsCest
 
 		// Assign tags.
 		$I->selectOption('convertkit-mm-options[convertkit-mapping-1]', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->selectOption('convertkit-mm-options[convertkit-mapping-1-cancel]', $_ENV['CONVERTKIT_API_TAG_CANCEL_NAME']);
 
 		// Click save settings.
 		$I->click('Save Settings');
@@ -122,9 +123,11 @@ class SettingsCest
 		// Confirm settings saved.
 		$I->see('Settings saved.');
 		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1]', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1-cancel]', $_ENV['CONVERTKIT_API_TAG_CANCEL_NAME']);
 
 		// Change tag back to 'None'.
 		$I->selectOption('convertkit-mm-options[convertkit-mapping-1]', '(None)');
+		$I->selectOption('convertkit-mm-options[convertkit-mapping-1-cancel]', '(None)');
 
 		// Click save settings.
 		$I->click('Save Settings');
@@ -135,6 +138,7 @@ class SettingsCest
 		// Confirm settings saved.
 		$I->see('Settings saved.');
 		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1]', '(None)');
+		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1-cancel]', '(None)');
 	}
 
 	/**
@@ -147,6 +151,10 @@ class SettingsCest
 	 */
 	public function testSaveProductTagAssignment(AcceptanceTester $I)
 	{
+		// Create a product.
+		$productReferenceKey = 'pTRLc9';
+		$productID           = $I->memberMouseCreateProduct($I, 'Product', $productReferenceKey);
+
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
 
@@ -154,7 +162,7 @@ class SettingsCest
 		$I->amOnAdminPage('options-general.php?page=convertkit-mm');
 
 		// Assign tags.
-		$I->selectOption('convertkit-mm-options[convertkit-mapping-1]', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->selectOption('convertkit-mm-options[convertkit-mapping-product-' . $productID . ']', $_ENV['CONVERTKIT_API_TAG_NAME']);
 
 		// Click save settings.
 		$I->click('Save Settings');
@@ -164,10 +172,10 @@ class SettingsCest
 
 		// Confirm settings saved.
 		$I->see('Settings saved.');
-		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1]', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-product-' . $productID . ']', $_ENV['CONVERTKIT_API_TAG_NAME']);
 
 		// Change tag back to 'None'.
-		$I->selectOption('convertkit-mm-options[convertkit-mapping-1]', '(None)');
+		$I->selectOption('convertkit-mm-options[convertkit-mapping-product-' . $productID . ']', '(None)');
 
 		// Click save settings.
 		$I->click('Save Settings');
@@ -177,7 +185,7 @@ class SettingsCest
 
 		// Confirm settings saved.
 		$I->see('Settings saved.');
-		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1]', '(None)');
+		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-product-' . $productID . ']', '(None)');
 	}
 
 	/**

--- a/tests/acceptance/general/SettingsCest.php
+++ b/tests/acceptance/general/SettingsCest.php
@@ -95,14 +95,14 @@ class SettingsCest
 	}
 
 	/**
-	 * Test that saving an invalid API Key on the settings screen
+	 * Test that level to tag mapping changes on the settings screen
 	 * works with no errors.
 	 *
 	 * @since   1.2.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testSaveTagAssignment(AcceptanceTester $I)
+	public function testSaveLevelTagAssignment(AcceptanceTester $I)
 	{
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
@@ -122,6 +122,62 @@ class SettingsCest
 		// Confirm settings saved.
 		$I->see('Settings saved.');
 		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1]', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Change tag back to 'None'.
+		$I->selectOption('convertkit-mm-options[convertkit-mapping-1]', '(None)');
+
+		// Click save settings.
+		$I->click('Save Settings');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm settings saved.
+		$I->see('Settings saved.');
+		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1]', '(None)');
+	}
+
+	/**
+	 * Test that product to tag mapping changes on the settings screen
+	 * works with no errors.
+	 *
+	 * @since   1.2.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSaveProductTagAssignment(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Go to the Plugin's Settings > General Screen.
+		$I->amOnAdminPage('options-general.php?page=convertkit-mm');
+
+		// Assign tags.
+		$I->selectOption('convertkit-mm-options[convertkit-mapping-1]', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click save settings.
+		$I->click('Save Settings');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm settings saved.
+		$I->see('Settings saved.');
+		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1]', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Change tag back to 'None'.
+		$I->selectOption('convertkit-mm-options[convertkit-mapping-1]', '(None)');
+
+		// Click save settings.
+		$I->click('Save Settings');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm settings saved.
+		$I->see('Settings saved.');
+		$I->seeOptionIsSelected('convertkit-mm-options[convertkit-mapping-1]', '(None)');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

On the settings screen, the `None` option would not display once a tag was assigned to a Membership Level, meaning it wasn't possible to remove a tag for a level at a later date.

This PR resolves by ensuring the `None` option is always available.

Before:
<img width="505" alt="Screenshot 2024-07-03 at 15 58 34" src="https://github.com/ConvertKit/convertkit-membermouse/assets/1462305/69ec0e2f-4aeb-4e05-a3f6-d6287d09edd2">

After:
<img width="990" alt="Screenshot 2024-07-03 at 15 52 44" src="https://github.com/ConvertKit/convertkit-membermouse/assets/1462305/e6787446-6eab-4f93-89ba-5a85c2d6f097">

## Testing

- `SettingsCest`: Updated tests to confirm the `None` option can be selected and is honored
- `MemberTagCest`: Added tests to confirm a subscriber is not tagged when tagging is not configured in the Plugin's settings for Membership Levels
- `ProductTagCest`: Added tests to confirm a subscriber is not tagged when tagging is not configured in the Plugin's settings for Products

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)