### PR TITLE
Add `languages` folder and build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ composer.lock
 log
 log.txt
 log-api.txt
+log-tag.txt
 phpstan.neon
 tests/_output
 vendor

--- a/.scripts/build.sh
+++ b/.scripts/build.sh
@@ -1,0 +1,9 @@
+# Build ACTIONS-FILTERS.md
+php create-actions-filters-docs.php
+
+# Generate .pot file
+php -n $(which wp) i18n make-pot ../ ../languages/convertkit-mm.pot
+
+# Build ZIP file
+rm ../convertkit-membermouse.zip
+cd .. && zip -r convertkit-membermouse.zip . -x "*.git*" -x ".scripts/*" -x ".wordpress-org/*" -x "tests/*" -x "vendor/*" -x "*.distignore" -x "*.env.*" -x "*codeception.*" -x "composer.json" -x "composer.lock" -x "*.md" -x "log.txt" -x "phpcs.xml" -x "phpstan.neon" -x "phpstan.neon.dist" -x "phpstan.neon.example" -x "*.DS_Store"

--- a/.scripts/class-read-actions-filters.php
+++ b/.scripts/class-read-actions-filters.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * Reads all Actions and Filters from the Plugin.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Reads all Actions and Filters from the Plugin.
+ *
+ * @since   1.0.0
+ */
+class Read_Actions_Filters {
+
+	/**
+	 * Extracts all instances of apply_filters() and do_action() calls from the specified folders and subfolders
+	 * PHP files.
+	 *
+	 * Results can be returned as an array or HTML.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param   array       $folders                        WordPress Plugin/Theme Folder Path(s) (e.g. /path/to/your/wp/wp-content/plugins/plugin-name).
+	 * @param   bool        $extract_filters                Extract apply_filters() calls.
+	 * @param   bool        $extract_actions                Extract do_action() calls.
+	 * @param   bool        $return_format                  Return Format (html|array).
+	 * @param   bool|string $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
+	 * @param   bool|string $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
+	 * @param   bool        $by_file                        Denote filters and actions by filename (false = group filters and actions if they appear across multiple files).
+	 * @return  bool|string                                 Output
+	 */
+	public function run( $folders, $extract_filters = true, $extract_actions = true, $return_format = 'html', $prefix_required = false, $prefix_required_replacement = false, $by_file = false ) {
+
+		$php_files = array();
+
+		// Make $folders an array.
+		if ( ! is_array( $folders ) ) {
+			$folders = array( $folders );
+		}
+
+		// Iterate through folders.
+		foreach ( $folders as $folder ) {
+
+			// Check the target folder exists.
+			if ( ! is_dir( $folder ) ) {
+				continue;
+			}
+
+			// Iterate through the folder and subfolders, finding any PHP files.
+			foreach ( new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $folder ) ) as $filename ) {
+
+				// Ignore directories.
+				if ( is_dir( $filename ) ) {
+					continue;
+				}
+
+				// Check if a PHP file.
+				if ( substr( $filename, -4 ) !== '.php' ) {
+					continue;
+				}
+
+				$php_files[] = $filename;
+
+			}
+		}
+
+		// Check if any PHP files were found.
+		if ( count( $php_files ) === 0 ) {
+			return false;
+		}
+
+		// Iterate through PHP files, extracting apply_filters() and do_action() calls.
+		$filters = array();
+		$actions = array();
+		foreach ( $php_files as $file ) {
+			// Read file contents.
+			$h = fopen( $file, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+			if ( ! $h ) {
+				continue;
+			}
+			$contents = fread( $h, filesize( $file ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+			fclose( $h ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+			// Get file name.
+			$file_only = str_replace( $folder, '', $file );
+
+			// Find all instances of apply_filters() and do_action().
+			if ( $extract_filters ) {
+				$filters = $this->find_matches( 'apply_filters', $filters, $contents, $file_only, html_entity_decode( $prefix_required ), $prefix_required_replacement, $by_file );
+			}
+			if ( $extract_actions ) {
+				$actions = $this->find_matches( 'do_action', $actions, $contents, $file_only, html_entity_decode( $prefix_required ), $prefix_required_replacement, $by_file );
+			}
+		}
+
+		// Return.
+		switch ( $return_format ) {
+			// Array.
+			case 'array':
+				return array(
+					'filters' => $filters,
+					'actions' => $actions,
+				);
+
+			// HTML.
+			default:
+				$html = '';
+				if ( $extract_filters && count( $filters ) > 0 ) {
+					$html .= $this->html( $filters, $by_file );
+				}
+				if ( $extract_actions && count( $actions ) > 0 ) {
+					$html .= $this->html( $actions, $by_file );
+				}
+
+				return $html;
+		}
+
+	}
+
+	/**
+	 * Performs a regex search on the given file contents, returning an array
+	 * of matches.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param   string      $function_to_search             Function to search (apply_filters|do_action).
+	 * @param   string      $results                        Existing Results.
+	 * @param   string      $contents                       File Contents.
+	 * @param   string      $file_only                      Filename (excluding full path).
+	 * @param   bool|string $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
+	 * @param   bool|string $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
+	 * @param   bool        $by_file                        Deliminate array results by file.
+	 * @return  array                                           Matches
+	 */
+	private function find_matches( $function_to_search, $results, $contents, $file_only, $prefix_required, $prefix_required_replacement = false, $by_file ) {
+
+		// Split the content into separate lines in an array.
+		$file_lines = explode( "\n", $contents );
+
+		// Items that we're searching for in the code.
+		$search = array(
+			'function'       => $function_to_search . '( ' . $prefix_required,
+			'docblock_open'  => '/**',
+			'docblock_close' => '*/',
+		);
+
+		// Array to store the last known positions of the docblock open and close lines.
+		$positions = array(
+			'docblock_open'  => 0,
+			'docblock_close' => 0,
+		);
+
+		// Iterate through each line of the file's code.
+		foreach ( $file_lines as $index => $line ) {
+			// Tidy up the line of code.
+			$line = trim( $line );
+
+			// If this line of code contains an opening or closing docblock, store its position and continue.
+			if ( $line === $search['docblock_open'] ) {
+				$positions['docblock_open'] = $index;
+				continue;
+			}
+			if ( $line === $search['docblock_close'] ) {
+				$positions['docblock_close'] = $index;
+				continue;
+			}
+
+			// Skip if this line doesn't contain what we're looking for.
+			if ( strpos( $line, $search['function'] ) === false ) {
+				continue;
+			}
+
+			// If here, we've found a function.
+			// Sanity check that we can find the filter / action.
+			preg_match( '/' . $function_to_search . '\((.*?)\)/s', $line, $matches );
+			if ( empty( $matches[0] ) ) {
+				continue;
+			}
+
+			// Build function array.
+			$function = array(
+				'name' => trim( substr( $matches[1], 0, ( strpos( $matches[1], ',' ) === false ? strlen( $matches[1] ) : strpos( $matches[1], ',' ) ) ) ),
+				'line' => $index,
+				'desc' => false,
+				'args' => array(),
+				'call' => $matches[0],
+			);
+
+			// Replace $prefix_required with $prefix_required_replacement, if specified.
+			if ( $prefix_required_replacement !== false ) {
+				$function['call'] = str_replace( $prefix_required, $prefix_required_replacement, $function['call'] );
+				$function['name'] = str_replace( $prefix_required, $prefix_required_replacement, $function['name'] );
+			}
+
+			// Trim out anything that isn't a letter, number, underscore or dash - such as a single quote.
+			$function['name'] = preg_replace( '/[^ \w-]/', '', $function['name'] );
+
+			// Use code to populate function arguments.
+			$args = explode( ',', str_replace( ')', '', $matches[0] ) );
+			unset( $args[0] );
+
+			foreach ( $args as $key => $arg ) {
+				// Tidy up the argument.
+				$args[ $key ] = trim( str_replace( 'this->', '', $arg ) );
+
+				// Add to the function arguments array.
+				$function['args'][ $args[ $key ] ] = array(
+					'type' => false,
+					'desc' => false,
+				);
+			}
+
+			// Check if there truly is a docblock immediately preceding the function.
+			// If so, use that to define the function arguments.
+			$docblock = '';
+			if ( $index - 1 === $positions['docblock_close'] ) {
+				// Docblock exists.
+				// Use docblock to populate function arguments.
+				$docblock = array_slice( $file_lines, $positions['docblock_open'], ( $positions['docblock_close'] - $positions['docblock_open'] + 1 ) );
+				$docblock = array_map( 'trim', $docblock );
+
+				// Parse docblock.
+				$docblock_results = $this->parse_docblock( $docblock );
+
+				// Merge results.
+				if ( $docblock_results['args'] !== false ) {
+					$function = array_merge( $function, $docblock_results );
+				}
+			}
+
+			// Define example usage call.
+			if ( stripos( $function['call'], 'apply_filters' ) !== false ) {
+				$function['call'] = 'add_filter( \'' . $function['name'] . '\', function( ' . trim( implode( ', ', array_map( 'trim', $args ) ) ) . ' ) {
+	// ... your code here
+	// Return value
+	return ' . trim( $args[1] ) . ';
+}, 10, ' . count( $args ) . ' );';
+			} elseif ( stripos( $function['call'], 'do_action' ) !== false ) {
+				$function['call'] = 'do_action( \'' . $function['name'] . '\', function( ' . trim( implode( ', ', array_map( 'trim', $args ) ) ) . ' ) {
+	// ... your code here
+}, 10, ' . count( $args ) . ' );';
+			}
+
+			// Add function to results array.
+			if ( $by_file ) {
+				$results[ $file_only ][ $function['name'] ] = $function;
+			} else {
+				$results[ $function['name'] ] = $function;
+			}
+		} // Close foreach code line loop.
+
+		return $results;
+
+	}
+
+	/**
+	 * Parses each line in the given docblock, returning an array
+	 * of results.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @param   array $docblock   Docblock Lines.
+	 * @return  array               Docblock Data.
+	 */
+	private function parse_docblock( $docblock ) {
+
+		// Array for results.
+		$results = array(
+			'desc'  => false,
+			'since' => false,
+			'args'  => false,
+		);
+
+		// Iterate through lines.
+		foreach ( $docblock as $line ) {
+
+			if ( ! preg_match( '/@(\w+) (.*)$/', $line, $matches ) ) {
+				// This might be the description.
+				if ( $line === '/**' || $line === '*/' || $line === '*' ) {
+					continue;
+				}
+
+				// Description.
+				$results['desc'] .= str_replace( '*', '', $line );
+				continue;
+			}
+
+			// Add to the results array.
+			switch ( $matches[1] ) {
+
+				case 'since':
+					// This can only be defined once, so don't store the value as an array.
+					$results[ $matches[1] ] = trim( $matches[2] );
+					break;
+
+				case 'param':
+					// Split out the parameter, type and description by any space or tab.
+					$param_parts = preg_split( '/\s\s+/', trim( $matches[2] ) );
+					$param_parts = array_map( 'trim', $param_parts );
+
+					// Remove empty param parts, which might occur when spaces are used instead of tabs.
+					foreach ( $param_parts as $key => $param_part ) {
+						if ( empty( trim( $param_part ) ) ) {
+							unset( $param_parts[ $key ] );
+						}
+					}
+
+					// Rekey array.
+					$param_parts = array_values( $param_parts );
+
+					// If we don't have 3 values in the array, parsing went wrong
+					// - most likely because there's only a single space between
+					// the variable and its description (we expect 2 spaces or more).
+					if ( count( $param_parts ) === 2 ) {
+						list ( $var, $desc ) = explode( ' ', $param_parts[1] );
+						$param_parts         = array(
+							$param_parts[0],
+							trim( $var ),
+							trim( $desc ),
+						);
+					}
+
+					// Add docblock information to the arguments array
+					// If the variable is $this->..., remove this-> so we have
+					// more human readable vars.
+					$results['args'][ trim( str_replace( 'this->', '', $param_parts[1] ) ) ] = array(
+						'type' => $param_parts[0],
+						'desc' => $param_parts[ count( $param_parts ) - 1 ],
+					);
+					break;
+
+				default:
+					$results[ $matches[1] ][] = trim( $matches[2] );
+					break;
+			}
+		}
+
+		// Tidy up results.
+		$results['desc']  = trim( $results['desc'] );
+		$results['since'] = $results['since'][0];
+
+		// Return.
+		return $results;
+
+	}
+
+	/**
+	 * Returns a HTML table of the given results
+	 *
+	 * @since   1.0.0
+	 *
+	 * @param   array $results        Results.
+	 * @param   bool  $by_file        Deliminate results by file.
+	 * @return  string  HTML
+	 */
+	private function html( $results, $by_file ) {
+
+		$html = '';
+
+		// Generate title based on type.
+		if ( $by_file ) {
+			// Index.
+			$html .= '<table>
+				<thead>
+					<tr>
+						<th>File</th>
+						<th>Filter Name</th>
+						<th>Description</th>
+					</tr>
+				</thead>
+				<tbody>';
+
+			foreach ( $results as $file => $functions ) {
+				$html .= '<tr>
+						<td colspan="3">' . $file . '</td>
+					</tr>';
+
+				// Index.
+				foreach ( $functions as $function ) {
+					$html .= '<tr>
+						<td>&nbsp;</td>
+						<td><a href="#' . $function['name'] . '"><code>' . $function['name'] . '</code></a></td>
+						<td>' . $function['desc'] . '</td>
+					</tr>';
+				}
+			}
+
+			$html .= '
+					</tbody>
+				</table>';
+
+			// Functions.
+			foreach ( $results as $file => $functions ) {
+				// Remove relative path.
+				$file = str_replace( '../', '', $file );
+
+				// Function Details.
+				foreach ( $functions as $function ) {
+					// Function name.
+					$html .= '<h3 id="' . $function['name'] . '">
+						' . $function['name'] . '
+						<code>' . $file . '::' . $function['line'] . '</code>
+					</h3>';
+
+					// Description.
+					if ( $function['desc'] !== false ) {
+						$html .= '<h4>Overview</h4>
+						<p>' . $function['desc'] . '</p>';
+					}
+
+					// Parameters.
+					$html .= '<h4>Parameters</h4>
+					<table>
+						<thead>
+							<tr>
+								<th>Parameter</th>
+								<th>Type</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody>';
+
+					foreach ( $function['args'] as $arg => $arg_data ) {
+						$html .= '<tr>
+							<td>' . $arg . '</td>
+							<td>' . ( $arg_data['type'] !== false ? $arg_data['type'] : 'Unknown' ) . '</td>
+							<td>' . ( $arg_data['desc'] !== false ? $arg_data['desc'] : 'N/A' ) . '</td>
+						</tr>';
+					}
+
+					$html .= '
+						</tbody>
+					</table>';
+
+					// Usage.
+					if ( $function['call'] !== false ) {
+						$html .= '<h4>Usage</h4>';
+						$html .= "\n";
+						$html .= '<pre>';
+						$html .= "\n";
+						$html .= $function['call'];
+						$html .= "\n";
+						$html .= '</pre>';
+						$html .= "\n";
+					}
+				}
+			}
+		}
+
+		return $html;
+
+	}
+
+}

--- a/.scripts/create-actions-filters-docs.php
+++ b/.scripts/create-actions-filters-docs.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Creates the ACTIONS-FILTERS.md markdown file, comprising of all ConvertKit
+ * action and filter hooks parsed from the Plugin code.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+// Setup Read Actions and Filters class.
+require_once 'class-read-actions-filters.php';
+$read_actions_filters = new Read_Actions_Filters();
+
+// Read Plugin filters.
+$filter_docs = $read_actions_filters->run(
+	// Define Plugin folders to include in Docs.
+	array(
+		'../admin',
+		'../includes',
+		'../views',
+	),
+	true, // Extract filters.
+	false, // Extract actions.
+	'html', // Return as HTML compatible with GitHub.
+	'\'convertkit_', // Only build Docs for actions starting with convertkit_.
+	false, // Change prefix.
+	true // Return by file.
+);
+$action_docs = $read_actions_filters->run(
+	// Define Plugin folders to include in Docs.
+	array(
+		'../admin',
+		'../includes',
+		'../views',
+	),
+	false, // Extract filters.
+	true, // Extract actions.
+	'html', // Return as HTML compatible with GitHub.
+	'\'convertkit_', // Only build Docs for actions starting with convertkit_.
+	false, // Change prefix.
+	true // Return by file.
+);
+
+// Build HTML.
+$html  = '<h1>Filters</h1>' . $filter_docs;
+$html .= '<h1>Actions</h1>' . $action_docs;
+
+// Write to file.
+file_put_contents( '../ACTIONS-FILTERS.md', $html ); // phpcs:ignore WordPress.WP.AlternativeFunctions

--- a/ACTIONS-FILTERS.md
+++ b/ACTIONS-FILTERS.md
@@ -1,0 +1,1 @@
+<h1>Filters</h1><h1>Actions</h1>

--- a/includes/class-convertkit-mm-i18n.php
+++ b/includes/class-convertkit-mm-i18n.php
@@ -25,7 +25,6 @@
  */
 class ConvertKit_MM_I18n {
 
-
 	/**
 	 * Load the plugin text domain for translation.
 	 *
@@ -33,13 +32,11 @@ class ConvertKit_MM_I18n {
 	 */
 	public function load_plugin_textdomain() {
 
-		load_plugin_textdomain(
-			'convertkit-mm',
-			false,
-			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
-		);
+		// If the .mo file for a given language is available in WP_LANG_DIR/convertkit-membermouse
+		// i.e. it's available as a translation at https://translate.wordpress.org/projects/wp-plugins/convertkit-membermouse/,
+		// it will be used instead of the .mo file in convertkit-membermouse/languages.
+		load_plugin_textdomain( 'convertkit-mm', false, 'convertkit-membermouse/languages' );
 
 	}
-
 
 }

--- a/languages/convertkit-mm.pot
+++ b/languages/convertkit-mm.pot
@@ -1,0 +1,118 @@
+# Copyright (C) 2024 ConvertKit
+# This file is distributed under the GPL-2.0+.
+msgid ""
+msgstr ""
+"Project-Id-Version: ConvertKit MemberMouse Integration 1.1.3\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/convertkit-membermouse\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2024-07-04T07:09:06+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.9.0\n"
+"X-Domain: convertkit-mm\n"
+
+#. Plugin Name of the plugin
+msgid "ConvertKit MemberMouse Integration"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "http://www.convertkit.com"
+msgstr ""
+
+#. Description of the plugin
+msgid "This plugin integrates ConvertKit with MemberMouse."
+msgstr ""
+
+#. Author of the plugin
+msgid "ConvertKit"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://convertkit.com"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:89
+msgid "General"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:96
+msgid "API Key"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:103
+msgid "Debug"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:110
+msgid "Assign Tags"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:126
+#: admin/class-convertkit-mm-admin.php:153
+msgid "Mapping"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:187
+msgid "ConvertKit MemberMouse Settings"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:188
+msgid "ConvertKit MemberMouse"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:237
+msgid "Add your API key below and then choose a default form to add subscribers to."
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:248
+msgid "Below is a list of the defined MemberMouse Membership Levels. Assign a membership level to a ConvertKit tag that will be assigned to members of that level."
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:263
+msgid "Settings"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:279
+msgid "Get your ConvertKit API Key"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:295
+msgid "Add data to a debug log."
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:308
+msgid "No MM Membership Levels have been added yet."
+msgstr ""
+
+#. translators: Link to MemberMouse Membership Levels
+#: admin/class-convertkit-mm-admin.php:312
+#: admin/class-convertkit-mm-admin.php:394
+msgid "You can add one <a href=\"%s\">here</a>."
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:337
+#: admin/class-convertkit-mm-admin.php:418
+msgid "Enter API key to retrieve list of tags."
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:341
+#: admin/class-convertkit-mm-admin.php:422
+msgid "No tags were returned from ConvertKit."
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:349
+#: admin/class-convertkit-mm-admin.php:365
+#: admin/class-convertkit-mm-admin.php:430
+msgid "Select a tag"
+msgstr ""
+
+#: admin/class-convertkit-mm-admin.php:390
+msgid "No MM Products have been added yet."
+msgstr ""
+
+#: includes/class-convertkit-mm-api.php:220
+msgid "Could not parse response from ConvertKit"
+msgstr ""


### PR DESCRIPTION
## Summary

- Adds the .pot file for translators to generate localization / translation files.
- Loads translations using `load_plugin_textdomain` configured to check WordPress for translations first, as we do in other WordPress Plugins
- Adds build scripts as used in our other WordPress Plugins

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)