### PR TITLE
Add Settings Class

### DIFF
--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -134,7 +134,7 @@ class ConvertKit_MM_Admin {
 
 		// If the API hasn't been configured, don't display any further settings, as
 		// we cannot fetch tags from the API to populate dropdown fields.
-		$this->settings = new ConvertKit_MM_Settings;
+		$this->settings = new ConvertKit_MM_Settings();
 		if ( ! $this->settings->has_api_key() ) {
 			return;
 		}
@@ -433,7 +433,7 @@ class ConvertKit_MM_Admin {
 			$args['name'],
 			$this->settings::SETTINGS_NAME,
 			$args['name'],
-			convertkit_mm_get_option( $args['name'] )
+			$this->settings->get_by_key( $args['name'] )
 		);
 
 		// Output field with description appended to it.

--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -17,25 +17,25 @@ class ConvertKit_MM_Admin {
 	/**
 	 * Holds the Settings Page Slug
 	 *
-	 * @since   1.3.0
+	 * @since   1.2.0
 	 *
 	 * @var     string
 	 */
 	const SETTINGS_PAGE_SLUG = 'convertkit-mm';
 
 	/**
-	 * Options table key
+	 * Holds the ConvertKit Settings class.
 	 *
-	 * @since   1.3.0
+	 * @since   1.2.2
 	 *
-	 * @var string
+	 * @var     null|ConvertKit_MM_Settings
 	 */
-	public $settings_key = CONVERTKIT_MM_NAME . '-options';
+	public $settings;
 
 	/**
 	 * Holds the ConvertKit Tags.
 	 *
-	 * @since   1.3.0
+	 * @since   1.2.0
 	 *
 	 * @var     null|array
 	 */
@@ -134,13 +134,13 @@ class ConvertKit_MM_Admin {
 
 		// If the API hasn't been configured, don't display any further settings, as
 		// we cannot fetch tags from the API to populate dropdown fields.
-		$settings = new ConvertKit_MM_Settings;
-		if ( ! $settings->has_api_key() ) {
+		$this->settings = new ConvertKit_MM_Settings;
+		if ( ! $this->settings->has_api_key() ) {
 			return;
 		}
 
 		// Initialize API.
-		$api = new ConvertKit_MM_API( $settings->get_api_key() );
+		$api = new ConvertKit_MM_API( $this->settings->get_api_key() );
 
 		// Get all tags from ConvertKit.
 		$this->tags = $api->get_tags();
@@ -208,10 +208,10 @@ class ConvertKit_MM_Admin {
 					'key'          => $key,
 
 					'name'         => 'convertkit-mapping-' . $key,
-					'value'        => convertkit_mm_get_option( 'convertkit-mapping-' . $key ),
+					'value'        => $this->settings->get_membership_level_mapping( $key ),
 
 					'name_cancel'  => 'convertkit-mapping-' . $key . '-cancel',
-					'value_cancel' => convertkit_mm_get_option( 'convertkit-mapping-' . $key . '-cancel' ),
+					'value_cancel' => $this->settings->get_membership_level_cancellation_mapping( $key ),
 
 					'options'      => $this->tags,
 				)
@@ -266,7 +266,7 @@ class ConvertKit_MM_Admin {
 					'key'     => $key,
 
 					'name'    => 'convertkit-mapping-product-' . $key,
-					'value'   => convertkit_mm_get_option( 'convertkit-mapping-product-' . $key ),
+					'value'   => $this->settings->get_product_mapping( $key ),
 
 					'options' => $this->tags,
 				)
@@ -322,10 +322,10 @@ class ConvertKit_MM_Admin {
 					'key'          => $key,
 
 					'name'         => 'convertkit-mapping-bundle-' . $key,
-					'value'        => convertkit_mm_get_option( 'convertkit-mapping-bundle-' . $key ),
+					'value'        => $this->settings->get_bundle_mapping( $key ),
 
 					'name_cancel'  => 'convertkit-mapping-bundle-' . $key . '-cancel',
-					'value_cancel' => convertkit_mm_get_option( 'convertkit-mapping-bundle-' . $key . '-cancel' ),
+					'value_cancel' => $this->settings->get_bundle_cancellation_mapping( $key ),
 
 					'options'      => $this->tags,
 				)
@@ -431,7 +431,7 @@ class ConvertKit_MM_Admin {
 			'<input type="text" class="%s" id="%s" name="%s[%s]" value="%s" />',
 			( is_array( $args['css_classes'] ) ? implode( ' ', $args['css_classes'] ) : 'regular-text' ),
 			$args['name'],
-			$this->settings_key,
+			$this->settings::SETTINGS_NAME,
 			$args['name'],
 			convertkit_mm_get_option( $args['name'] )
 		);
@@ -462,7 +462,7 @@ class ConvertKit_MM_Admin {
 		$html .= sprintf(
 			'<input type="checkbox" id="%s" name="%s[%s]" class="%s" value="%s" %s />',
 			$args['name'],
-			$this->settings_key,
+			$this->settings::SETTINGS_NAME,
 			$args['name'],
 			( array_key_exists( 'css_classes', $args ) && is_array( $args['css_classes'] ) ? implode( ' ', $args['css_classes'] ) : '' ),
 			$args['value'],
@@ -542,7 +542,7 @@ class ConvertKit_MM_Admin {
 		$html .= sprintf(
 			'<select id="%s" name="%s[%s]" size="1">',
 			$name,
-			$this->settings_key,
+			$this->settings::SETTINGS_NAME,
 			$name
 		);
 

--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -134,12 +134,13 @@ class ConvertKit_MM_Admin {
 
 		// If the API hasn't been configured, don't display any further settings, as
 		// we cannot fetch tags from the API to populate dropdown fields.
-		if ( empty( convertkit_mm_get_option( 'api-key' ) ) ) {
+		$settings = new ConvertKit_MM_Settings;
+		if ( ! $settings->has_api_key() ) {
 			return;
 		}
 
 		// Initialize API.
-		$api = new ConvertKit_MM_API( convertkit_mm_get_option( 'api-key' ) );
+		$api = new ConvertKit_MM_API( $settings->get_api_key() );
 
 		// Get all tags from ConvertKit.
 		$this->tags = $api->get_tags();

--- a/convertkit-membermouse.php
+++ b/convertkit-membermouse.php
@@ -39,6 +39,7 @@ define( 'CONVERTKIT_MM_VERSION', '1.2.1' );
 // Load plugin files that are always required.
 require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm-actions.php';
 require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm-api.php';
+require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm-settings.php';
 require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm.php';
 require CONVERTKIT_MM_PATH . 'includes/convertkit-mm-functions.php';
 

--- a/includes/class-convertkit-mm-actions.php
+++ b/includes/class-convertkit-mm-actions.php
@@ -217,10 +217,10 @@ class ConvertKit_MM_Actions {
 		// Determine the status change.
 		switch ( $member_data['bundle_status_name'] ) {
 			case 'Active':
-				$tag_id = $this->settings->get_bundle_mapping( $purchase_data['bundle_id'] );
+				$tag_id = $this->settings->get_bundle_mapping( $member_data['bundle_id'] );
 				break;
 			case 'Canceled':
-				$tag_id = $this->settings->get_bundle_cancellation_mapping( $purchase_data['bundle_id'] );
+				$tag_id = $this->settings->get_bundle_cancellation_mapping( $member_data['bundle_id'] );
 				break;
 
 			default:

--- a/includes/class-convertkit-mm-settings.php
+++ b/includes/class-convertkit-mm-settings.php
@@ -212,8 +212,7 @@ class ConvertKit_MM_Settings {
 		$key = 'convertkit-mapping-' . ( $type !== 'level' ? $type . '-' : '' ) . $id;
 
 		// If requesting a 'cancel' setting, append this to the key.
-		// Products don't support cancellation, so ignore this flag if it's for a product.
-		if ( $is_cancellation_mapping && $type !== 'product' ) {
+		if ( $is_cancellation_mapping ) {
 			$key .= '-cancel';
 		}
 

--- a/includes/class-convertkit-mm-settings.php
+++ b/includes/class-convertkit-mm-settings.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * ConvertKit Plugin Settings class.
+ *
+ * @package ConvertKit_MM
+ * @author ConvertKit
+ */
+
+/**
+ * Class to read ConvertKit Plugin Settings.
+ *
+ * @since   1.2.2
+ */
+class ConvertKit_MM_Settings {
+
+	/**
+	 * Holds the Settings Key that stores site wide ConvertKit settings
+	 *
+	 * @since 	1.2.2
+	 *
+	 * @var     string
+	 */
+	const SETTINGS_NAME = 'convertkit-mm-options';
+
+	/**
+	 * Holds the Settings
+	 *
+	 * @since 	1.2.2
+	 *
+	 * @var     array
+	 */
+	private $settings = array();
+
+	/**
+	 * Constructor. Reads settings from options table, falling back to defaults
+	 * if no settings exist.
+	 *
+	 * @since   1.2.2
+	 */
+	public function __construct() {
+
+		// Get Settings.
+		$settings = get_option( self::SETTINGS_NAME );
+
+		// If no Settings exist, falback to default settings.
+		if ( ! $settings ) {
+			$this->settings = $this->get_defaults();
+		} else {
+			$this->settings = array_merge( $this->get_defaults(), $settings );
+		}
+
+	}
+
+	/**
+	 * Returns Plugin settings.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  array
+	 */
+	public function get() {
+
+		return $this->settings;
+
+	}
+
+	/**
+	 * Returns the API Key Plugin setting.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  string
+	 */
+	public function get_api_key() {
+
+		// Return API Key from settings.
+		return $this->settings['api_key'];
+
+	}
+
+	/**
+	 * Returns whether the API Key has been set in the Plugin settings.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  bool
+	 */
+	public function has_api_key() {
+
+		return ( ! empty( $this->get_api_key() ) ? true : false );
+
+	}
+
+	/**
+	 * Returns the mapping setting for the given MemberMouse Membership Level ID.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	int 	$id 	Membership Level ID.
+	 * @return 	string 			Setting
+	 */
+	public function get_membership_level_mapping( $id ) {
+
+		if ( ! array_key_exists( 'convertkit-mapping-' . $key, $this->settings ) ) {
+			return '';
+		}
+
+		return $this->settings[ 'convertkit-mapping-' . $key ];
+
+	}
+
+	/**
+	 * Returns the mapping setting for the given MemberMouse Product ID.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	int 	$id 	Membership Level ID.
+	 * @return 	string 			Setting
+	 */
+	public function get_product_mapping( $id ) {
+
+		if ( ! array_key_exists( 'convertkit-mapping-product-' . $key, $this->settings ) ) {
+			return '';
+		}
+
+		return $this->settings[ 'convertkit-mapping-product-' . $key ];
+
+	}
+
+	/**
+	 * Returns the mapping setting for the given MemberMouse Bundle ID.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	int 	$id 	Membership Level ID.
+	 * @return 	string 			Setting
+	 */
+	public function get_bundle_mapping( $id ) {
+
+		if ( ! array_key_exists( 'convertkit-mapping-bundle-' . $key, $this->settings ) ) {
+			return '';
+		}
+
+		return $this->settings[ 'convertkit-mapping-bundle-' . $key ];
+
+	}
+
+	/**
+	 * The default settings, used when the ConvertKit Plugin Settings haven't been saved
+	 * e.g. on a new installation.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  array
+	 */
+	public function get_defaults() {
+
+		$defaults = array(
+			'api_key'         => '', // string.
+		);
+
+		/**
+		 * The default settings, used when the ConvertKit Plugin Settings haven't been saved
+		 * e.g. on a new installation.
+		 *
+		 * @since   1.2.2
+		 *
+		 * @param   array   $defaults   Default Settings.
+		 */
+		$defaults = apply_filters( 'convertkit_settings_get_defaults', $defaults );
+
+		return $defaults;
+
+	}
+
+	/**
+	 * Saves the given array of settings to the WordPress options table.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   array $settings   Settings.
+	 */
+	public function save( $settings ) {
+
+		update_option( self::SETTINGS_NAME, array_merge( $this->get(), $settings ) );
+
+		// Reload settings in class, to reflect changes.
+		$this->settings = get_option( self::SETTINGS_NAME );
+
+	}
+
+}

--- a/includes/class-convertkit-mm-settings.php
+++ b/includes/class-convertkit-mm-settings.php
@@ -16,7 +16,7 @@ class ConvertKit_MM_Settings {
 	/**
 	 * Holds the Settings Key that stores site wide ConvertKit settings
 	 *
-	 * @since 	1.2.2
+	 * @since   1.2.2
 	 *
 	 * @var     string
 	 */
@@ -25,7 +25,7 @@ class ConvertKit_MM_Settings {
 	/**
 	 * Holds the Settings
 	 *
-	 * @since 	1.2.2
+	 * @since   1.2.2
 	 *
 	 * @var     array
 	 */
@@ -65,6 +65,24 @@ class ConvertKit_MM_Settings {
 	}
 
 	/**
+	 * Returns the setting for the given key.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   string $key    Settings key.
+	 * @return  string
+	 */
+	public function get_by_key( $key ) {
+
+		if ( ! array_key_exists( $key, $this->settings ) ) {
+			return '';
+		}
+
+		return $this->settings[ $key ];
+
+	}
+
+	/**
 	 * Returns the API Key Plugin setting.
 	 *
 	 * @since   1.2.2
@@ -92,12 +110,25 @@ class ConvertKit_MM_Settings {
 	}
 
 	/**
+	 * Returns whether debugging is enabled in the Plugin settings.
+	 *
+	 * @since   1.2.2
+	 *
+	 * @return  bool
+	 */
+	public function debug_enabled() {
+
+		return ( $this->settings['debug'] === 'on' ? true : false );
+
+	}
+
+	/**
 	 * Returns the mapping setting for the given MemberMouse Membership Level ID.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	int 	$id 	Membership Level ID.
-	 * @return 	string 			Setting
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   int $id     Membership Level ID.
+	 * @return  string          Setting
 	 */
 	public function get_membership_level_mapping( $id ) {
 
@@ -108,11 +139,11 @@ class ConvertKit_MM_Settings {
 	/**
 	 * Returns the mapping setting for the given MemberMouse Membership Level ID
 	 * when the Level is removed from the User.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	int 	$id 	Membership Level ID.
-	 * @return 	string 			Setting
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   int $id     Membership Level ID.
+	 * @return  string          Setting
 	 */
 	public function get_membership_level_cancellation_mapping( $id ) {
 
@@ -122,11 +153,11 @@ class ConvertKit_MM_Settings {
 
 	/**
 	 * Returns the mapping setting for the given MemberMouse Product ID.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	int 	$id 	Membership Level ID.
-	 * @return 	string 			Setting
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   int $id     Membership Level ID.
+	 * @return  string          Setting
 	 */
 	public function get_product_mapping( $id ) {
 
@@ -136,11 +167,11 @@ class ConvertKit_MM_Settings {
 
 	/**
 	 * Returns the mapping setting for the given MemberMouse Bundle ID.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	int 	$id 	Membership Level ID.
-	 * @return 	string 			Setting
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   int $id     Membership Level ID.
+	 * @return  string          Setting
 	 */
 	public function get_bundle_mapping( $id ) {
 
@@ -151,11 +182,11 @@ class ConvertKit_MM_Settings {
 	/**
 	 * Returns the mapping setting for the given MemberMouse Bundle ID
 	 * when the Bundle is removed from the User.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	int 	$id 	Bundle ID.
-	 * @return 	string 			Setting
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   int $id     Bundle ID.
+	 * @return  string          Setting
 	 */
 	public function get_bundle_cancellation_mapping( $id ) {
 
@@ -166,13 +197,13 @@ class ConvertKit_MM_Settings {
 	/**
 	 * Returns the mapping setting for the given MemberMouse resource ID, type
 	 * and whether the mapping is for the 'cancellation'.
-	 * 
-	 * @since 	1.2.2
-	 * 
-	 * @param 	int 	$id 						Level, Product or Bundle ID.
-	 * @param 	string  $type 						Mapping type (level,bundle,product).
-	 * @param 	bool 	$is_cancellation_mapping 	If the mapping setting is for the 'cancel' action.
-	 * @return 	string 								Setting
+	 *
+	 * @since   1.2.2
+	 *
+	 * @param   int    $id                         Level, Product or Bundle ID.
+	 * @param   string $type                       Mapping type (level,bundle,product).
+	 * @param   bool   $is_cancellation_mapping    If the mapping setting is for the 'cancel' action.
+	 * @return  string                              Setting
 	 */
 	private function get_mapping( $id, $type = 'level', $is_cancellation_mapping = false ) {
 
@@ -186,14 +217,7 @@ class ConvertKit_MM_Settings {
 			$key .= '-cancel';
 		}
 
-		// Return a blank string if the setting key doesn't exist i.e. settings were not saved
-		// or the level, product or bundle was added to MemberMouse but we don't yet have a setting
-		// mapped for it.
-		if ( ! array_key_exists( $key, $this->settings ) ) {
-			return '';
-		}
-
-		return $this->settings[ $key ];
+		return $this->get_by_key( $key );
 
 	}
 
@@ -208,7 +232,8 @@ class ConvertKit_MM_Settings {
 	public function get_defaults() {
 
 		$defaults = array(
-			'api-key'         => '', // string.
+			'api-key' => '', // string.
+			'debug'   => '', // string.
 		);
 
 		/**

--- a/includes/class-convertkit-mm-settings.php
+++ b/includes/class-convertkit-mm-settings.php
@@ -74,7 +74,7 @@ class ConvertKit_MM_Settings {
 	public function get_api_key() {
 
 		// Return API Key from settings.
-		return $this->settings['api_key'];
+		return $this->settings['api-key'];
 
 	}
 
@@ -101,11 +101,22 @@ class ConvertKit_MM_Settings {
 	 */
 	public function get_membership_level_mapping( $id ) {
 
-		if ( ! array_key_exists( 'convertkit-mapping-' . $key, $this->settings ) ) {
-			return '';
-		}
+		return $this->get_mapping( $id, 'level' );
 
-		return $this->settings[ 'convertkit-mapping-' . $key ];
+	}
+
+	/**
+	 * Returns the mapping setting for the given MemberMouse Membership Level ID
+	 * when the Level is removed from the User.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	int 	$id 	Membership Level ID.
+	 * @return 	string 			Setting
+	 */
+	public function get_membership_level_cancellation_mapping( $id ) {
+
+		return $this->get_mapping( $id, 'level', true );
 
 	}
 
@@ -119,11 +130,7 @@ class ConvertKit_MM_Settings {
 	 */
 	public function get_product_mapping( $id ) {
 
-		if ( ! array_key_exists( 'convertkit-mapping-product-' . $key, $this->settings ) ) {
-			return '';
-		}
-
-		return $this->settings[ 'convertkit-mapping-product-' . $key ];
+		return $this->get_mapping( $id, 'product' );
 
 	}
 
@@ -137,11 +144,56 @@ class ConvertKit_MM_Settings {
 	 */
 	public function get_bundle_mapping( $id ) {
 
-		if ( ! array_key_exists( 'convertkit-mapping-bundle-' . $key, $this->settings ) ) {
+		return $this->get_mapping( $id, 'bundle' );
+
+	}
+
+	/**
+	 * Returns the mapping setting for the given MemberMouse Bundle ID
+	 * when the Bundle is removed from the User.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	int 	$id 	Bundle ID.
+	 * @return 	string 			Setting
+	 */
+	public function get_bundle_cancellation_mapping( $id ) {
+
+		return $this->get_mapping( $id, 'bundle', true );
+
+	}
+
+	/**
+	 * Returns the mapping setting for the given MemberMouse resource ID, type
+	 * and whether the mapping is for the 'cancellation'.
+	 * 
+	 * @since 	1.2.2
+	 * 
+	 * @param 	int 	$id 						Level, Product or Bundle ID.
+	 * @param 	string  $type 						Mapping type (level,bundle,product).
+	 * @param 	bool 	$is_cancellation_mapping 	If the mapping setting is for the 'cancel' action.
+	 * @return 	string 								Setting
+	 */
+	private function get_mapping( $id, $type = 'level', $is_cancellation_mapping = false ) {
+
+		// Build key we're looking for in the array of settings.
+		// Membership levels are stored as `convertkit-mapping-ID`, so don't append the type in this instance.
+		$key = 'convertkit-mapping-' . ( $type !== 'level' ? $type . '-' : '' ) . $id;
+
+		// If requesting a 'cancel' setting, append this to the key.
+		// Products don't support cancellation, so ignore this flag if it's for a product.
+		if ( $is_cancellation_mapping && $type !== 'product' ) {
+			$key .= '-cancel';
+		}
+
+		// Return a blank string if the setting key doesn't exist i.e. settings were not saved
+		// or the level, product or bundle was added to MemberMouse but we don't yet have a setting
+		// mapped for it.
+		if ( ! array_key_exists( $key, $this->settings ) ) {
 			return '';
 		}
 
-		return $this->settings[ 'convertkit-mapping-bundle-' . $key ];
+		return $this->settings[ $key ];
 
 	}
 
@@ -156,7 +208,7 @@ class ConvertKit_MM_Settings {
 	public function get_defaults() {
 
 		$defaults = array(
-			'api_key'         => '', // string.
+			'api-key'         => '', // string.
 		);
 
 		/**

--- a/includes/convertkit-mm-functions.php
+++ b/includes/convertkit-mm-functions.php
@@ -7,27 +7,6 @@
  */
 
 /**
- * Get the setting option requested.
- *
- * @since   1.0.0
- *
- * @param   string $option_name    Option name.
- * @return  string                  Option value
- */
-function convertkit_mm_get_option( $option_name ) {
-
-	$options = get_option( CONVERTKIT_MM_NAME . '-options' );
-	$option  = '';
-
-	if ( ! empty( $options[ $option_name ] ) ) {
-		$option = $options[ $option_name ];
-	}
-
-	return $option;
-
-}
-
-/**
  * Debug log.
  *
  * @since   1.0.2
@@ -37,13 +16,18 @@ function convertkit_mm_get_option( $option_name ) {
  */
 function convertkit_mm_log( $log, $message ) {
 
-	$debug = convertkit_mm_get_option( 'debug' );
+	// Initialize settings class.
+	$settings = new ConvertKit_MM_Settings();
 
-	if ( 'on' === $debug ) {
-		$log     = fopen( CONVERTKIT_MM_PATH . '/log-' . $log . '.txt', 'a+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
-		$message = '[' . gmdate( 'd-m-Y H:i:s' ) . '] ' . $message . PHP_EOL;
-		fwrite( $log, $message ); // phpcs:ignore WordPress.WP.AlternativeFunctions
-		fclose( $log ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+	// Bail if debugging isn't enabled.
+	if ( ! $settings->debug_enabled() ) {
+		return;
 	}
+
+	// Write to log.
+	$log     = fopen( CONVERTKIT_MM_PATH . '/log-' . $log . '.txt', 'a+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+	$message = '[' . gmdate( 'd-m-Y H:i:s' ) . '] ' . $message . PHP_EOL;
+	fwrite( $log, $message ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+	fclose( $log ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 
 }


### PR DESCRIPTION
## Summary

Adds the `ConvertKit_MM_Settings` class, with various methods to fetch the API Key, debug settings and mapping configurations, similar to the main ConvertKit Plugin.

This replaces the `convertkit_mm_get_option` helper method, and creates a settings class that can be updated to support OAuth with later v4 API work.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)