### PR TITLE
Tests: Confirm Tag applied on Membership Level Reassignment

### DIFF
--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -100,6 +100,23 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Removes the given tag ID from the given subscriber ID.
+	 *
+	 * @since   1.2.1
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 * @param   int              $tagID         Tag ID.
+	 */
+	public function apiSubscriberRemoveTag($I, $subscriberID, $tagID)
+	{
+		$this->apiRequest(
+			'subscribers/' . $subscriberID . '/tags/' . $tagID,
+			'DELETE'
+		);
+	}
+
+	/**
 	 * Check the given email address does not exists as a subscriber.
 	 *
 	 * @since   1.2.0

--- a/tests/_support/Helper/Acceptance/MemberMouse.php
+++ b/tests/_support/Helper/Acceptance/MemberMouse.php
@@ -97,10 +97,11 @@ class MemberMouse extends \Codeception\Module
 	 *
 	 * @since   1.2.0
 	 *
-	 * @param   AcceptanceTester $I             AcceptanceTester.
-	 * @param   string           $emailAddress  Email Address.
+	 * @param   AcceptanceTester $I                     AcceptanceTester.
+	 * @param   string           $emailAddress          Email Address.
+	 * @param   string           $membershipLevelName   Membership Level Name to assign to member.
 	 */
-	public function memberMouseCreateMember($I, $emailAddress)
+	public function memberMouseCreateMember($I, $emailAddress, $membershipLevelName = 'Free Membership')
 	{
 		// Navigate to MemberMouse > Manage Members.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -108,10 +109,12 @@ class MemberMouse extends \Codeception\Module
 		// Create Member.
 		$I->click('Create Member');
 		$I->waitForElementVisible('#mm-new-member-form-container');
+		$I->selectOption('#mm-new-membership-selector', $membershipLevelName);
 		$I->fillField('#mm-new-first-name', 'First');
 		$I->fillField('#mm-new-last-name', 'Last');
 		$I->fillField('#mm-new-email', $emailAddress);
 		$I->fillField('#mm-new-password', '12345678');
+
 		$I->click('Create Member', '.mm-dialog-button-container');
 		$I->waitForElementNotVisible('#mm-new-member-form-container');
 


### PR DESCRIPTION
## Summary

[Confirms the workflow in this reported issue works correctly](https://github.com/ConvertKit/convertkit-membermouse/issues/16), with the member being assigned to the applicable ConvertKit tag when they are assigned to a different membership level after being cancelled from the first membership level. 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)